### PR TITLE
Display time elapsed for each task

### DIFF
--- a/pkg/alfred/context.go
+++ b/pkg/alfred/context.go
@@ -16,6 +16,7 @@ type Context struct {
 	TaskName      string
 	Stdin         string
 	Started       time.Time
+	TaskStarted   time.Time
 	Log           map[string]*os.File
 	Args          []string
 	AllArgs       string
@@ -78,20 +79,21 @@ func (c *Context) GetVar(key, defaults string) string {
 // InitialContext will return an empty context
 func InitialContext(args []string) *Context {
 	return &Context{
-		TaskName: "n/a",
-		Args:     args,
-		AllArgs:  strings.Join(args, " "),
-		Register: make(map[string]string),
-		Log:      make(map[string]*os.File, 0),
-		Ok:       true, // innocent until proven guilty
-		Started:  time.Now(),
-		Status:   "",
-		Vars:     make(map[string]string, 0),
-		Lock:     &sync.Mutex{},
-		Out:      os.Stdout,
-		lock:     &sync.Mutex{},
-		rootDir:  curDir(),
-		FileName: "alfred",
+		TaskName:    "n/a",
+		Args:        args,
+		AllArgs:     strings.Join(args, " "),
+		Register:    make(map[string]string),
+		Log:         make(map[string]*os.File, 0),
+		Ok:          true, // innocent until proven guilty
+		Started:     time.Now(),
+		TaskStarted: time.Now(),
+		Status:      "",
+		Vars:        make(map[string]string, 0),
+		Lock:        &sync.Mutex{},
+		Out:         os.Stdout,
+		lock:        &sync.Mutex{},
+		rootDir:     curDir(),
+		FileName:    "alfred",
 		Text: TextConfig{
 			// TODO: I don't like this, let me chew on this a bit more
 			Success:     ansi.ColorCode("green"),

--- a/pkg/alfred/summary.go
+++ b/pkg/alfred/summary.go
@@ -15,8 +15,8 @@ func summary(task Task, context *Context, tasks map[string]Task) {
 
 func result(task Task, context *Context, tasks map[string]Task) {
 	if context.Ok {
-		outOK("{{ .Text.SuccessIcon }} ok ["+strings.Join(context.Args, ", ")+"]", "elapsed time {{ .Text.Grey }}'{{ .Text.Success }}"+time.Since(context.Started).Round(time.Second).String()+"{{ .Text.Grey }}'", context)
+		outOK("{{ .Text.SuccessIcon }} ok ["+strings.Join(context.Args, ", ")+"]", "elapsed time {{ .Text.Grey }}'{{ .Text.Success }}"+time.Since(context.TaskStarted).Round(time.Second).String()+"{{ .Text.Grey }}'", context)
 	} else {
-		outFail("{{ .Text.FailureIcon }} failed ["+strings.Join(context.Args, ", ")+"]", "elapsed time {{ .Text.Grey }}'{{ .Text.Success }}"+time.Since(context.Started).Round(time.Second).String()+"{{ .Text.Grey }}'", context)
+		outFail("{{ .Text.FailureIcon }} failed ["+strings.Join(context.Args, ", ")+"]", "elapsed time {{ .Text.Grey }}'{{ .Text.Success }}"+time.Since(context.TaskStarted).Round(time.Second).String()+"{{ .Text.Grey }}'", context)
 	}
 }

--- a/pkg/alfred/task.go
+++ b/pkg/alfred/task.go
@@ -3,6 +3,7 @@ package alfred
 import (
 	"os"
 	"strings"
+	"time"
 
 	event "github.com/kcmerrill/hook"
 )
@@ -24,6 +25,9 @@ func NewTask(task string, context *Context, loadedTasks map[string]Task) {
 
 	// innocent until proven guilty
 	context.Ok = true
+
+	// start time of the task
+	context.TaskStarted = time.Now()
 
 	// set our taskname
 	_, context.TaskName = TaskParser(task, "alfred:list")


### PR DESCRIPTION
Display time elapsed for each task, instead of the total time (that is already displayed at the beginning of the line)

In the case of a task ground, the time displayed is the time elapsed by the whole group.

Example:
```
#alfred.yml
test.group:
  summary: sleep 1
  tasks: test.2 test.3

test.3:
  summary: sleep 3
  command: sleep 3

test.2:
  summary: sleep 2
  command: sleep 2

test.1:
  summary: sleep 1
  command: sleep 1

test:
  summary: sleep
  tasks: test.group test.1 test.2 test.3
```

```
$ alfred.exe test
[      0s] (10 May 19 16:37 PDT) [/tmp] test started [] sleep
[      0s] (10 May 19 16:37 PDT) [/tmp] test tasks test.group, test.1, test.2, test.3
[      0s] (10 May 19 16:37 PDT) [/tmp] test.group started [] sleep 1
[      0s] (10 May 19 16:37 PDT) [/tmp] test.group tasks test.2, test.3
[      0s] (10 May 19 16:37 PDT) [/tmp] test.2 started [] sleep 2
[      2s] (10 May 19 16:37 PDT) [/tmp] test.2 ✔ ok [] elapsed time '2s'
[      2s] (10 May 19 16:37 PDT) [/tmp] test.3 started [] sleep 3
[      5s] (10 May 19 16:37 PDT) [/tmp] test.3 ✔ ok [] elapsed time '3s'
[      5s] (10 May 19 16:37 PDT) [/tmp] test.group ✔ ok [] elapsed time '5s'
[      5s] (10 May 19 16:37 PDT) [/tmp] test.1 started [] sleep 1
[      6s] (10 May 19 16:37 PDT) [/tmp] test.1 ✔ ok [] elapsed time '1s'
[      6s] (10 May 19 16:37 PDT) [/tmp] test.2 started [] sleep 2
[      8s] (10 May 19 16:37 PDT) [/tmp] test.2 ✔ ok [] elapsed time '2s'
[      8s] (10 May 19 16:37 PDT) [/tmp] test.3 started [] sleep 3
[     11s] (10 May 19 16:37 PDT) [/tmp] test.3 ✔ ok [] elapsed time '3s'
[     11s] (10 May 19 16:37 PDT) [/tmp] test ✔ ok [] elapsed time '11s'
```